### PR TITLE
Adding Parse Limit

### DIFF
--- a/etc/config/copyright-exclude
+++ b/etc/config/copyright-exclude
@@ -6,3 +6,4 @@ MANIFEST.MF
 /etc/config/copyright-exclude
 /etc/config/copyright.txt
 /bundles/dist/src/main/resources/README.txt
+/impl/src/test/java/org/eclipse/parsson/tests/JsonDocumentParseLimitTest.java

--- a/impl/src/main/java/org/eclipse/parsson/JsonContext.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonContext.java
@@ -44,7 +44,7 @@ final class JsonContext {
     private static final int DEFAULT_MAX_DEPTH = 1000;
 
     /** Default maximum number of characters to parse from one document. */
-    private static final int DEFAULT_MAX_PARSING_LIMIT = 15_000_000;
+    private static final long DEFAULT_MAX_PARSING_LIMIT = 15_000_000;
 
     /**
      * Custom char[] pool instance property. Can be set in properties {@code Map} only.
@@ -63,7 +63,7 @@ final class JsonContext {
     private final int depthLimit;
 
     // Maximum number of characters to parse from one document
-    private final int maxParsingLimit;
+    private final long maxParsingLimit;
 
     // Whether JSON pretty printing is enabled
     private final boolean prettyPrinting;
@@ -83,7 +83,7 @@ final class JsonContext {
         this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINTEGER_SCALE, config, DEFAULT_MAX_BIGINTEGER_SCALE);
         this.bigDecimalLengthLimit = getIntConfig(JsonConfig.MAX_BIGDECIMAL_LEN, config, DEFAULT_MAX_BIGDECIMAL_LEN);
         this.depthLimit = getIntConfig(JsonConfig.MAX_DEPTH, config, DEFAULT_MAX_DEPTH);
-        this.maxParsingLimit = getIntConfig(JsonConfig.MAX_PARSING_LIMIT, config, DEFAULT_MAX_PARSING_LIMIT);
+        this.maxParsingLimit = getLongConfig(JsonConfig.MAX_PARSING_LIMIT, config, DEFAULT_MAX_PARSING_LIMIT);
         this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
         this.rejectDuplicateKeys = getBooleanConfig(JsonConfig.REJECT_DUPLICATE_KEYS, config);
         this.bufferPool = getBufferPool(config, defaultPool);
@@ -101,7 +101,7 @@ final class JsonContext {
         this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINTEGER_SCALE, config, DEFAULT_MAX_BIGINTEGER_SCALE);
         this.bigDecimalLengthLimit = getIntConfig(JsonConfig.MAX_BIGDECIMAL_LEN, config, DEFAULT_MAX_BIGDECIMAL_LEN);
         this.depthLimit = getIntConfig(JsonConfig.MAX_DEPTH, config, DEFAULT_MAX_DEPTH);
-        this.maxParsingLimit = getIntConfig(JsonConfig.MAX_PARSING_LIMIT, config, DEFAULT_MAX_PARSING_LIMIT);
+        this.maxParsingLimit = getLongConfig(JsonConfig.MAX_PARSING_LIMIT, config, DEFAULT_MAX_PARSING_LIMIT);
         this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
         this.rejectDuplicateKeys = getBooleanConfig(JsonConfig.REJECT_DUPLICATE_KEYS, config);
         this.bufferPool = getBufferPool(config, defaultPool);
@@ -129,7 +129,7 @@ final class JsonContext {
         return depthLimit;
     }
 
-    int maxParsingLimit() {
+    long maxParsingLimit() {
         return maxParsingLimit;
     }
 
@@ -161,6 +161,17 @@ final class JsonContext {
         return intConfig != null ? intConfig : defaultValue;
     }
 
+    private static long getLongConfig(String propertyName, Map<String, ?> config, long defaultValue) throws JsonException {
+        // Try config Map first
+        Long longConfig = config != null ? getLongProperty(propertyName, config) : null;
+        if (longConfig != null) {
+            return longConfig;
+        }
+        // Try system properties as fallback.
+        longConfig = getLongSystemProperty(propertyName);
+        return longConfig != null ? longConfig : defaultValue;
+    }
+
     private static boolean getBooleanConfig(String propertyName, Map<String, ?> config) throws JsonException {
         // Try config Map first
         Boolean booleanConfig = config != null ? getBooleanProperty(propertyName, config) : null;
@@ -187,6 +198,22 @@ final class JsonContext {
                               propertyName, property.getClass().getName()));
     }
 
+    private static Long getLongProperty(String propertyName, Map<String, ?> config) throws JsonException {
+        Object property = config.get(propertyName);
+        if (property == null) {
+            return null;
+        }
+        if (property instanceof Number) {
+            return ((Number) property).longValue();
+        }
+        if (property instanceof String) {
+            return propertyStringToLong(propertyName, (String) property);
+        }
+        throw new JsonException(
+                String.format("Could not convert %s property of type %s to Long",
+                              propertyName, property.getClass().getName()));
+    }
+
     // Returns true when property exists or null otherwise. Property value is ignored.
     private static Boolean getBooleanProperty(String propertyName, Map<String, ?> config) throws JsonException {
         return config.containsKey(propertyName) ? true : null;
@@ -199,6 +226,14 @@ final class JsonContext {
             return null;
         }
         return propertyStringToInt(propertyName, systemProperty);
+    }
+
+    private static Long getLongSystemProperty(String propertyName) throws JsonException {
+        String systemProperty = getSystemProperty(propertyName);
+        if (systemProperty == null) {
+            return null;
+        }
+        return propertyStringToLong(propertyName, systemProperty);
     }
 
     // Returns true when property exists or false otherwise. Property value is ignored.
@@ -219,6 +254,15 @@ final class JsonContext {
     private static int propertyStringToInt(String propertyName, String propertyValue) throws JsonException {
         try {
             return Integer.parseInt(propertyValue);
+        } catch (NumberFormatException ex) {
+            throw new JsonException(
+                    String.format("Value of %s property is not a number", propertyName), ex);
+        }
+    }
+
+    private static long propertyStringToLong(String propertyName, String propertyValue) throws JsonException {
+        try {
+            return Long.parseLong(propertyValue);
         } catch (NumberFormatException ex) {
             throw new JsonException(
                     String.format("Value of %s property is not a number", propertyName), ex);

--- a/impl/src/main/java/org/eclipse/parsson/JsonContext.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonContext.java
@@ -44,7 +44,7 @@ final class JsonContext {
     private static final int DEFAULT_MAX_DEPTH = 1000;
 
     /** Default maximum number of characters to parse from one document. */
-    private static final long DEFAULT_MAX_PARSING_LIMIT = 15_000_000;
+    private static final int DEFAULT_MAX_PARSING_LIMIT = 15_000_000;
 
     /**
      * Custom char[] pool instance property. Can be set in properties {@code Map} only.
@@ -63,7 +63,7 @@ final class JsonContext {
     private final int depthLimit;
 
     // Maximum number of characters to parse from one document
-    private final long maxParsingLimit;
+    private final int maxParsingLimit;
 
     // Whether JSON pretty printing is enabled
     private final boolean prettyPrinting;
@@ -83,7 +83,7 @@ final class JsonContext {
         this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINTEGER_SCALE, config, DEFAULT_MAX_BIGINTEGER_SCALE);
         this.bigDecimalLengthLimit = getIntConfig(JsonConfig.MAX_BIGDECIMAL_LEN, config, DEFAULT_MAX_BIGDECIMAL_LEN);
         this.depthLimit = getIntConfig(JsonConfig.MAX_DEPTH, config, DEFAULT_MAX_DEPTH);
-        this.maxParsingLimit = getLongConfig(JsonConfig.MAX_PARSING_LIMIT, config, DEFAULT_MAX_PARSING_LIMIT);
+        this.maxParsingLimit = getIntConfig(JsonConfig.MAX_PARSING_LIMIT, config, DEFAULT_MAX_PARSING_LIMIT);
         this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
         this.rejectDuplicateKeys = getBooleanConfig(JsonConfig.REJECT_DUPLICATE_KEYS, config);
         this.bufferPool = getBufferPool(config, defaultPool);
@@ -101,7 +101,7 @@ final class JsonContext {
         this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINTEGER_SCALE, config, DEFAULT_MAX_BIGINTEGER_SCALE);
         this.bigDecimalLengthLimit = getIntConfig(JsonConfig.MAX_BIGDECIMAL_LEN, config, DEFAULT_MAX_BIGDECIMAL_LEN);
         this.depthLimit = getIntConfig(JsonConfig.MAX_DEPTH, config, DEFAULT_MAX_DEPTH);
-        this.maxParsingLimit = getLongConfig(JsonConfig.MAX_PARSING_LIMIT, config, DEFAULT_MAX_PARSING_LIMIT);
+        this.maxParsingLimit = getIntConfig(JsonConfig.MAX_PARSING_LIMIT, config, DEFAULT_MAX_PARSING_LIMIT);
         this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
         this.rejectDuplicateKeys = getBooleanConfig(JsonConfig.REJECT_DUPLICATE_KEYS, config);
         this.bufferPool = getBufferPool(config, defaultPool);
@@ -129,7 +129,7 @@ final class JsonContext {
         return depthLimit;
     }
 
-    long maxParsingLimit() {
+    int maxParsingLimit() {
         return maxParsingLimit;
     }
 
@@ -161,16 +161,6 @@ final class JsonContext {
         return intConfig != null ? intConfig : defaultValue;
     }
 
-    private static long getLongConfig(String propertyName, Map<String, ?> config, long defaultValue) throws JsonException {
-        // Try config Map first
-        Long longConfig = config != null ? getLongProperty(propertyName, config) : null;
-        if (longConfig != null) {
-            return longConfig;
-        }
-        // Try system properties as fallback.
-        longConfig = getLongSystemProperty(propertyName);
-        return longConfig != null ? longConfig : defaultValue;
-    }
 
     private static boolean getBooleanConfig(String propertyName, Map<String, ?> config) throws JsonException {
         // Try config Map first
@@ -198,21 +188,6 @@ final class JsonContext {
                               propertyName, property.getClass().getName()));
     }
 
-    private static Long getLongProperty(String propertyName, Map<String, ?> config) throws JsonException {
-        Object property = config.get(propertyName);
-        if (property == null) {
-            return null;
-        }
-        if (property instanceof Number) {
-            return ((Number) property).longValue();
-        }
-        if (property instanceof String) {
-            return propertyStringToLong(propertyName, (String) property);
-        }
-        throw new JsonException(
-                String.format("Could not convert %s property of type %s to Long",
-                              propertyName, property.getClass().getName()));
-    }
 
     // Returns true when property exists or null otherwise. Property value is ignored.
     private static Boolean getBooleanProperty(String propertyName, Map<String, ?> config) throws JsonException {
@@ -228,13 +203,6 @@ final class JsonContext {
         return propertyStringToInt(propertyName, systemProperty);
     }
 
-    private static Long getLongSystemProperty(String propertyName) throws JsonException {
-        String systemProperty = getSystemProperty(propertyName);
-        if (systemProperty == null) {
-            return null;
-        }
-        return propertyStringToLong(propertyName, systemProperty);
-    }
 
     // Returns true when property exists or false otherwise. Property value is ignored.
     private static boolean getBooleanSystemProperty(String propertyName) throws JsonException {
@@ -260,14 +228,6 @@ final class JsonContext {
         }
     }
 
-    private static long propertyStringToLong(String propertyName, String propertyValue) throws JsonException {
-        try {
-            return Long.parseLong(propertyValue);
-        } catch (NumberFormatException ex) {
-            throw new JsonException(
-                    String.format("Value of %s property is not a number", propertyName), ex);
-        }
-    }
 
     // Constructor helper: Copy provider specific properties Map. Only specified properties are added.
     // Instance prettyPrinting and rejectDuplicateKeys variables must be initialized before

--- a/impl/src/main/java/org/eclipse/parsson/JsonContext.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -43,6 +43,9 @@ final class JsonContext {
     /** Default maximum level of nesting. */
     private static final int DEFAULT_MAX_DEPTH = 1000;
 
+    /** Default maximum number of characters to parse from one document. */
+    private static final int DEFAULT_MAX_PARSING_LIMIT = 15_000_000;
+
     /**
      * Custom char[] pool instance property. Can be set in properties {@code Map} only.
      */
@@ -58,6 +61,9 @@ final class JsonContext {
 
     // Maximum depth to parse
     private final int depthLimit;
+
+    // Maximum number of characters to parse from one document
+    private final int maxParsingLimit;
 
     // Whether JSON pretty printing is enabled
     private final boolean prettyPrinting;
@@ -77,6 +83,7 @@ final class JsonContext {
         this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINTEGER_SCALE, config, DEFAULT_MAX_BIGINTEGER_SCALE);
         this.bigDecimalLengthLimit = getIntConfig(JsonConfig.MAX_BIGDECIMAL_LEN, config, DEFAULT_MAX_BIGDECIMAL_LEN);
         this.depthLimit = getIntConfig(JsonConfig.MAX_DEPTH, config, DEFAULT_MAX_DEPTH);
+        this.maxParsingLimit = getIntConfig(JsonConfig.MAX_PARSING_LIMIT, config, DEFAULT_MAX_PARSING_LIMIT);
         this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
         this.rejectDuplicateKeys = getBooleanConfig(JsonConfig.REJECT_DUPLICATE_KEYS, config);
         this.bufferPool = getBufferPool(config, defaultPool);
@@ -94,6 +101,7 @@ final class JsonContext {
         this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINTEGER_SCALE, config, DEFAULT_MAX_BIGINTEGER_SCALE);
         this.bigDecimalLengthLimit = getIntConfig(JsonConfig.MAX_BIGDECIMAL_LEN, config, DEFAULT_MAX_BIGDECIMAL_LEN);
         this.depthLimit = getIntConfig(JsonConfig.MAX_DEPTH, config, DEFAULT_MAX_DEPTH);
+        this.maxParsingLimit = getIntConfig(JsonConfig.MAX_PARSING_LIMIT, config, DEFAULT_MAX_PARSING_LIMIT);
         this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
         this.rejectDuplicateKeys = getBooleanConfig(JsonConfig.REJECT_DUPLICATE_KEYS, config);
         this.bufferPool = getBufferPool(config, defaultPool);
@@ -119,6 +127,10 @@ final class JsonContext {
 
     int depthLimit() {
         return depthLimit;
+    }
+
+    int maxParsingLimit() {
+        return maxParsingLimit;
     }
 
     boolean prettyPrinting() {

--- a/impl/src/main/java/org/eclipse/parsson/JsonMessages.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/eclipse/parsson/JsonMessages.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonMessages.java
@@ -125,6 +125,10 @@ final class JsonMessages {
         return localize("parser.duplicate.key", name);
     }
 
+    static String PARSER_COUNT_EXCEEDED(int limit) {
+        return localize("parser.count.exceeded", limit);
+    }
+
     // generator messages
     static String GENERATOR_FLUSH_IO_ERR() {
         return localize("generator.flush.io.err");

--- a/impl/src/main/java/org/eclipse/parsson/JsonMessages.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonMessages.java
@@ -125,7 +125,7 @@ final class JsonMessages {
         return localize("parser.duplicate.key", name);
     }
 
-    static String PARSER_COUNT_EXCEEDED(long limit) {
+    static String PARSER_COUNT_EXCEEDED(int limit) {
         return localize("parser.count.exceeded", limit);
     }
 

--- a/impl/src/main/java/org/eclipse/parsson/JsonMessages.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonMessages.java
@@ -125,7 +125,7 @@ final class JsonMessages {
         return localize("parser.duplicate.key", name);
     }
 
-    static String PARSER_COUNT_EXCEEDED(int limit) {
+    static String PARSER_COUNT_EXCEEDED(long limit) {
         return localize("parser.count.exceeded", limit);
     }
 

--- a/impl/src/main/java/org/eclipse/parsson/JsonTokenizer.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonTokenizer.java
@@ -90,7 +90,7 @@ final class JsonTokenizer implements Closeable {
     // which is higher than the literal JSON source length due to lookahead
     // operations needed to determine parsing completion (e.g., detecting EOF after the
     // last token). See JsonConfig.MAX_PARSING_LIMIT for details.
-    private long documentParseCount = 0;
+    private int documentParseCount = 0;
 
     private boolean minus;
     private boolean fracOrExp;

--- a/impl/src/main/java/org/eclipse/parsson/JsonTokenizer.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonTokenizer.java
@@ -90,7 +90,7 @@ final class JsonTokenizer implements Closeable {
     // which is higher than the literal JSON source length due to lookahead
     // operations needed to determine parsing completion (e.g., detecting EOF after the
     // last token). See JsonConfig.MAX_PARSING_LIMIT for details.
-    private int documentParseCount = 0;
+    private long documentParseCount = 0;
 
     private boolean minus;
     private boolean fracOrExp;

--- a/impl/src/main/java/org/eclipse/parsson/JsonTokenizer.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonTokenizer.java
@@ -480,9 +480,7 @@ final class JsonTokenizer implements Closeable {
 
     private void incrementParseCount() {
         if (++documentParseCount > jsonContext.maxParsingLimit()) {
-            throw new JsonException(String.format(
-                "Document parsing count exceeded maximum allowed value of %d",
-                jsonContext.maxParsingLimit()));
+            throw new JsonException(JsonMessages.PARSER_COUNT_EXCEEDED(jsonContext.maxParsingLimit()));
         }
     }
 

--- a/impl/src/main/java/org/eclipse/parsson/JsonTokenizer.java
+++ b/impl/src/main/java/org/eclipse/parsson/JsonTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -85,6 +85,13 @@ final class JsonTokenizer implements Closeable {
     private long bufferOffset = 0;
     private boolean closed = false;
 
+    // Tracks the total number of parse operations (character reads) during JSON parsing.
+    // Note: This count represents parse operations by the parser's control flow,
+    // which is higher than the literal JSON source length due to lookahead
+    // operations needed to determine parsing completion (e.g., detecting EOF after the
+    // last token). See JsonConfig.MAX_PARSING_LIMIT for details.
+    private int documentParseCount = 0;
+
     private boolean minus;
     private boolean fracOrExp;
     private BigDecimal bd;
@@ -136,6 +143,7 @@ final class JsonTokenizer implements Closeable {
             if (inPlace) {
                 int ch;
                 while(readBegin < readEnd && ((ch=buf[readBegin]) >= 0x20) && ch != '\\') {
+                    incrementParseCount();
                     if (ch == '"') {
                         storeEnd = readBegin++; // ++ to consume quote char
                         return;                 // Got the entire string
@@ -214,6 +222,7 @@ final class JsonTokenizer implements Closeable {
     // of resizing, filling up the buf, adjusting the pointers
     private int readNumberChar() {
         if (readBegin < readEnd) {
+            incrementParseCount();
             return buf[readBegin++];
         } else {
             storeEnd = readBegin;
@@ -462,9 +471,18 @@ final class JsonTokenizer implements Closeable {
                 readBegin = storeEnd;
                 readEnd = readBegin+len;
             }
+            incrementParseCount();
             return buf[readBegin++];
         } catch (IOException ioe) {
             throw new JsonException(JsonMessages.TOKENIZER_IO_ERR(), ioe);
+        }
+    }
+
+    private void incrementParseCount() {
+        if (++documentParseCount > jsonContext.maxParsingLimit()) {
+            throw new JsonException(String.format(
+                "Document parsing count exceeded maximum allowed value of %d",
+                jsonContext.maxParsingLimit()));
         }
     }
 

--- a/impl/src/main/java/org/eclipse/parsson/api/JsonConfig.java
+++ b/impl/src/main/java/org/eclipse/parsson/api/JsonConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -39,6 +39,22 @@ public interface JsonConfig {
      * Default value is set to {@code 1000}.
      */
     String MAX_DEPTH = "org.eclipse.parsson.maxDepth";
+
+    /**
+     * Configuration property to limit the total number of characters consumed during parsing
+     * of a single JSON document.
+     * <p>
+     * This property limits all characters consumed by the tokenizer during parsing,
+     * including whitespace, structural characters, object member names, string values,
+     * number lexemes, and literal keywords.
+     * <p>
+     * <b>Important:</b> This limit represents the number of characters the parser must
+     * consume to complete parsing, which is higher than the literal JSON
+     * source length.
+     * <p>
+     * Default value is set to {@code 15000000} (15 million characters).
+     */
+    String MAX_PARSING_LIMIT = "org.eclipse.parsson.maxParsingLimit";
 
     /**
      * Configuration property to reject duplicate keys.

--- a/impl/src/main/resources/org/eclipse/parsson/messages.properties
+++ b/impl/src/main/resources/org/eclipse/parsson/messages.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2026 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/resources/org/eclipse/parsson/messages.properties
+++ b/impl/src/main/resources/org/eclipse/parsson/messages.properties
@@ -46,6 +46,7 @@ parser.input.enc.detect.failed=Cannot auto-detect encoding, not enough chars
 parser.input.enc.detect.ioerr=I/O error while auto-detecting the encoding of stream
 parser.duplicate.key=Duplicate key ''{0}'' is not allowed
 parser.input.nested.too.deep=Input is too deeply nested {0}
+parser.count.exceeded=Document parsing count exceeded maximum allowed value of {0}
 
 generator.flush.io.err=I/O error while flushing generated JSON
 generator.close.io.err=I/O error while closing JsonGenerator

--- a/impl/src/test/java/org/eclipse/parsson/tests/JsonDocumentParseLimitTest.java
+++ b/impl/src/test/java/org/eclipse/parsson/tests/JsonDocumentParseLimitTest.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution, and is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * AI Disclosure: This file was largely AI-generated. The AI-generated
+ * portions are made available under CC0-1.0 and not subject to the
+ * project's license. The human contributor has reviewed and verified
+ * that the code is correct.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 AND CC0-1.0
+ * Assisted-by: IBM Bob 1.0.2
+ */
+
+package org.eclipse.parsson.tests;
+
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.json.Json;
+import jakarta.json.JsonException;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonReaderFactory;
+import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonParserFactory;
+
+import org.eclipse.parsson.api.JsonConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that documents exceeding the max parsing limit are
+ * rejected.
+ */
+public class JsonDocumentParseLimitTest {
+
+    // Helper method to repeat a string (Java 9 API compatible)
+    private static String repeat(String str, int count) {
+        StringBuilder sb = new StringBuilder(str.length() * count);
+        for (int i = 0; i < count; i++) {
+            sb.append(str);
+        }
+        return sb.toString();
+    }
+
+    @Test
+    void testDocumentParseLimitExceeded() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonConfig.MAX_PARSING_LIMIT, 1000);
+        
+        // Create JSON with >1000 characters
+        StringBuilder json = new StringBuilder("[");
+        for (int i = 0; i < 400; i++) {
+            if (i > 0) {
+                json.append(",");
+            }
+            json.append(i);
+        }
+        json.append("]");
+        
+        JsonReaderFactory factory = Json.createReaderFactory(config);
+        Assertions.assertThrows(JsonException.class, () -> {
+            try (JsonReader reader = factory.createReader(new StringReader(json.toString()))) {
+                reader.readArray();
+            }
+        });
+    }
+
+    @Test
+    void testDocumentParseLimitNotExceeded() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonConfig.MAX_PARSING_LIMIT, 2000);
+        
+        // Create JSON with <2000 characters
+        StringBuilder json = new StringBuilder("[");
+        for (int i = 0; i < 100; i++) {
+            if (i > 0) {
+                json.append(",");
+            }
+            json.append(i);
+        }
+        json.append("]");
+        
+        JsonReaderFactory factory = Json.createReaderFactory(config);
+        try (JsonReader reader = factory.createReader(new StringReader(json.toString()))) {
+            reader.readArray(); // Should succeed
+        }
+    }
+
+    @Test
+    void testDocumentParseLimitWithLargeString() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonConfig.MAX_PARSING_LIMIT, 500);
+        
+        // Create JSON with a long string value that exceeds character limit
+        String longString = repeat("a", 600);
+        String json = "{\"key\":\"" + longString + "\"}";
+        
+        JsonReaderFactory factory = Json.createReaderFactory(config);
+        Assertions.assertThrows(JsonException.class, () -> {
+            try (JsonReader reader = factory.createReader(new StringReader(json))) {
+                reader.readObject();
+            }
+        });
+    }
+
+    @Test
+    void testDocumentParseLimitWithLargeNumber() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonConfig.MAX_PARSING_LIMIT, 100);
+        
+        // Create JSON with a very long number
+        String longNumber = "1" + repeat("0", 150);
+        String json = "[" + longNumber + "]";
+        
+        JsonReaderFactory factory = Json.createReaderFactory(config);
+        Assertions.assertThrows(JsonException.class, () -> {
+            try (JsonReader reader = factory.createReader(new StringReader(json))) {
+                reader.readArray();
+            }
+        });
+    }
+
+    @Test
+    void testDocumentParseLimitWithWhitespaceFlooding() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonConfig.MAX_PARSING_LIMIT, 200);
+        
+        // Create JSON with excessive whitespace
+        String json = repeat("   ", 100) + "[1,2,3]" + repeat("   ", 100);
+        
+        JsonReaderFactory factory = Json.createReaderFactory(config);
+        Assertions.assertThrows(JsonException.class, () -> {
+            try (JsonReader reader = factory.createReader(new StringReader(json))) {
+                reader.readArray();
+            }
+        });
+    }
+
+    @Test
+    void testDocumentParseLimitWithLargeObject() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonConfig.MAX_PARSING_LIMIT, 500);
+        
+        // Create JSON object with many keys
+        StringBuilder json = new StringBuilder("{");
+        for (int i = 0; i < 100; i++) {
+            if (i > 0) {
+                json.append(",");
+            }
+            json.append("\"key").append(i).append("\":").append(i);
+        }
+        json.append("}");
+        
+        JsonReaderFactory factory = Json.createReaderFactory(config);
+        Assertions.assertThrows(JsonException.class, () -> {
+            try (JsonReader reader = factory.createReader(new StringReader(json.toString()))) {
+                reader.readObject();
+            }
+        });
+    }
+
+    @Test
+    void testDocumentParseLimitWithMixedContent() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonConfig.MAX_PARSING_LIMIT, 1000);
+        
+        // Create JSON with mixed content that exceeds character limit
+        StringBuilder json = new StringBuilder("{\"array\":[");
+        for (int i = 0; i < 100; i++) {
+            if (i > 0) {
+                json.append(",");
+            }
+            json.append(i);
+        }
+        json.append("],\"object\":{");
+        for (int i = 0; i < 100; i++) {
+            if (i > 0) {
+                json.append(",");
+            }
+            json.append("\"k").append(i).append("\":").append(i);
+        }
+        json.append("}}");
+        
+        JsonReaderFactory factory = Json.createReaderFactory(config);
+        Assertions.assertThrows(JsonException.class, () -> {
+            try (JsonReader reader = factory.createReader(new StringReader(json.toString()))) {
+                reader.readObject();
+            }
+        });
+    }
+
+    @Test
+    void testDocumentParseLimitEdgeCaseAtLimit() {
+        Map<String, Object> config = new HashMap<>();
+        // Note: Parser may consume additional characters beyond the literal source length
+        // due to lookahead operations and number parsing that reads ahead to find token boundaries.
+        // For JSON "[1,2,3,4]" (9 chars), the parser's token-driven control flow and number
+        // parsing lookahead means it consumes more than the literal source length.
+        // Setting a generous limit to allow successful parsing.
+        config.put(JsonConfig.MAX_PARSING_LIMIT, 13);
+        
+        // Create JSON with exactly 9 characters: [1,2,3,4]
+        String json = "[1,2,3,4]";
+        
+        JsonReaderFactory factory = Json.createReaderFactory(config);
+        try (JsonReader reader = factory.createReader(new StringReader(json))) {
+            reader.readArray(); // Should succeed
+        }
+    }
+
+    @Test
+    void testDocumentParseLimitEdgeCaseOverLimit() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonConfig.MAX_PARSING_LIMIT, 8);
+        
+        // Create JSON with 9 characters: [1,2,3,4]
+
+        String json = "[1,2,3,4]";
+        
+        JsonReaderFactory factory = Json.createReaderFactory(config);
+        Assertions.assertThrows(JsonException.class, () -> {
+            try (JsonReader reader = factory.createReader(new StringReader(json))) {
+                reader.readArray();
+            }
+        });
+    }
+
+    @Test
+    void testDocumentParseLimitWithParser() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonConfig.MAX_PARSING_LIMIT, 500);
+        
+        // Create JSON that exceeds character limit
+        StringBuilder json = new StringBuilder("[");
+        for (int i = 0; i < 200; i++) {
+            if (i > 0) {
+                json.append(",");
+            }
+            json.append(i);
+        }
+        json.append("]");
+        
+        JsonParserFactory factory = Json.createParserFactory(config);
+        Assertions.assertThrows(JsonException.class, () -> {
+            try (JsonParser parser = factory.createParser(new StringReader(json.toString()))) {
+                while (parser.hasNext()) {
+                    parser.next();
+                }
+            }
+        });
+    }
+
+    @Test
+    void testDefaultDocumentParseLimit() {
+        // Test that default limit (15M) allows reasonable JSON
+        StringBuilder json = new StringBuilder("[");
+        for (int i = 0; i < 10000; i++) {
+            if (i > 0) {
+                json.append(",");
+            }
+            json.append(i);
+        }
+        json.append("]");
+        
+        // Should succeed with default limit
+        try (JsonReader reader = Json.createReader(new StringReader(json.toString()))) {
+            reader.readArray();
+        }
+    }
+
+    @Test
+    void testDocumentParseLimitWithNestedStructures() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonConfig.MAX_PARSING_LIMIT, 200);
+        
+        // Create deeply nested structure that exceeds character limit
+        StringBuilder json = new StringBuilder();
+        for (int i = 0; i < 50; i++) {
+            json.append("{\"a\":");
+        }
+        json.append("1");
+        for (int i = 0; i < 50; i++) {
+            json.append("}");
+        }
+        
+        JsonReaderFactory factory = Json.createReaderFactory(config);
+        Assertions.assertThrows(JsonException.class, () -> {
+            try (JsonReader reader = factory.createReader(new StringReader(json.toString()))) {
+                reader.readObject();
+            }
+        });
+    }
+
+    @Test
+    void testDocumentParseLimitWithBooleanAndNull() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonConfig.MAX_PARSING_LIMIT, 50);
+        
+        // JSON with booleans and nulls (54 characters)
+        String json = "[true,false,null,true,false,null,true,false,null,true]";
+        
+        JsonReaderFactory factory = Json.createReaderFactory(config);
+        Assertions.assertThrows(JsonException.class, () -> {
+            try (JsonReader reader = factory.createReader(new StringReader(json))) {
+                reader.readArray();
+            }
+        });
+    }
+
+    @Test
+    void testDocumentCharLimitWithInterTokenWhitespace() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonConfig.MAX_PARSING_LIMIT, 60);
+        
+        // JSON with whitespace between tokens
+        String json = "[ 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9 , 10 , 11 , 12 , 13 , 14 , 15 , 16 , 17 , 18 , 19 , 20 ]";
+        
+        JsonReaderFactory factory = Json.createReaderFactory(config);
+        Assertions.assertThrows(JsonException.class, () -> {
+            try (JsonReader reader = factory.createReader(new StringReader(json))) {
+                reader.readArray();
+            }
+        });
+    }
+
+    @Test
+    void testDocumentParseLimitWithEscapeSequences() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonConfig.MAX_PARSING_LIMIT, 100);
+        
+        // JSON with escape sequences (each \n counts as 2 characters in source)
+        String json = "{\"key\":\"" + repeat("line\\n", 20) + "\"}";
+        
+        JsonReaderFactory factory = Json.createReaderFactory(config);
+        Assertions.assertThrows(JsonException.class, () -> {
+            try (JsonReader reader = factory.createReader(new StringReader(json))) {
+                reader.readObject();
+            }
+        });
+    }
+
+    @Test
+    void testDocumentParseLimitWithLongKeys() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(JsonConfig.MAX_PARSING_LIMIT, 200);
+        
+        // JSON with very long key names
+        String longKey = repeat("m", 300);
+        String json = "{\"" + longKey + "\":1,}";
+        
+        JsonReaderFactory factory = Json.createReaderFactory(config);
+        Assertions.assertThrows(JsonException.class, () -> {
+            try (JsonReader reader = factory.createReader(new StringReader(json))) {
+                reader.readObject();
+            }
+        });
+    }
+}


### PR DESCRIPTION
Adds a config property with default value to limit the total number of parsing operations done on a Json document. If this limit is exceeded an Exception is throw. 